### PR TITLE
fix(ocean-rs-mutator-webhook-cfg): invalid spec

### DIFF
--- a/deployment/mutatingwebhook-template.tmpl
+++ b/deployment/mutatingwebhook-template.tmpl
@@ -23,3 +23,5 @@ webhooks:
     namespaceSelector:
       matchLabels:
         spot.io/mutate-resource: enabled    
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None


### PR DESCRIPTION
Fixes https://github.com/spotinst/ocean-right-sizing-mutator/issues/2